### PR TITLE
add grap card to group entity page

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -39,7 +39,7 @@ import {
   EntityOwnershipCard,
 } from '@backstage/plugin-org';
 import { EntityTechdocsContent } from '@backstage/plugin-techdocs';
-import { EmptyState, ItemCardGrid } from '@backstage/core-components';
+import { EmptyState } from '@backstage/core-components';
 import {
   Direction,
   EntityCatalogGraphCard,
@@ -53,6 +53,8 @@ import {
   RELATION_HAS_PART,
   RELATION_PART_OF,
   RELATION_PROVIDES_API,
+  RELATION_CHILD_OF,
+  RELATION_PARENT_OF,
 } from '@backstage/catalog-model';
 
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
@@ -60,7 +62,6 @@ import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 
 import { EntityAdrContent, isAdrAvailable } from '@backstage/plugin-adr';
 import { TeamAPI } from '@internal/plugin-teamapi';
-
 
 import {
   isGitlabAvailable,
@@ -321,7 +322,21 @@ const groupPage = (
           <EntityOwnershipCard variant="gridItem" />
         </Grid>
         <Grid item xs={12}>
-          <EntityMembersListCard />
+          <EntityMembersListCard showAggregateMembersToggle/>
+        </Grid>
+        <Grid item xs={12}>
+          <EntityCatalogGraphCard
+            variant="gridItem"
+            direction={Direction.LEFT_RIGHT}
+            title="closely related groups"
+            maxDepth={2}
+            height={400}
+            relations={[
+              RELATION_PARENT_OF,
+              RELATION_CHILD_OF,
+            ]}
+            unidirectional={false}
+          />
         </Grid>
       </Grid>
     </EntityLayout.Route>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -328,7 +328,7 @@ const groupPage = (
           <EntityCatalogGraphCard
             variant="gridItem"
             direction={Direction.LEFT_RIGHT}
-            title="closely related groups"
+            title="Graph"
             maxDepth={2}
             height={400}
             relations={[


### PR DESCRIPTION
j'ajoute, sur la page d'un groupe, un graph pour mieux visualiser les relations avec les autres groupes

![image](https://github.com/Zenika/backstage-demo/assets/34473421/0b2ca994-f7c6-4efe-a993-e66f8444a2ff)
